### PR TITLE
SOL-1789: Add directories to contain themes for ecommerce and edx-platform

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+.idea/
+
+edx-platform/**/cms/**/css/
+edx-platform/**/lms/**/css/

--- a/README.md
+++ b/README.md
@@ -1,4 +1,0 @@
-Sample edX Themes
-==========
-
-This is a sample repository for edx themes.

--- a/README.rst
+++ b/README.rst
@@ -1,0 +1,7 @@
+Sample Themes for OpenEdx
+=========================
+This repository contains sample themes for LMS (Learning Management System), Studio and the E-Commerce service.
+
+A more detailed description of how you apply themes to Studio, the LMS and the E-Commerce service and guidelines for theming templates, assets and styles can be found here_.
+
+.. _here: http://edx.readthedocs.io/projects/edx-installing-configuring-and-running/en/open-release-eucalyptus.master/configuration/changing_appearance/theming/index.html

--- a/ecommerce/README.rst
+++ b/ecommerce/README.rst
@@ -1,0 +1,30 @@
+Sample Themes for E-Commerce Service
+====================================
+This directory contains themes for E-Commerce Service,
+following directory structure should be followed for each theme.
+
+
+.. code-block:: text
+
+   themes
+      |
+      └─ my-theme
+          ├── README.rst
+          ├── static
+          |      └── images
+          |      |     └── logo.png
+          |      |
+          |      └── sass
+          |            └── partials
+          |                   └── utilities
+          |                           └── _variables.scss
+          |
+          └── templates
+                └── oscar
+                |     └── dashboard
+                |             └── index.html
+                └── 404.html
+
+A more detailed description of how you apply themes to the E-Commerce service and guidelines for theming templates, assets and styles can be found here_.
+
+.. _here: https://github.com/edx/ecommerce/blob/master/docs/theming.rst

--- a/edx-platform/README.rst
+++ b/edx-platform/README.rst
@@ -1,0 +1,41 @@
+Sample Themes for LMS and Studio
+================================
+This directory contains themes for LMS (Learning Management System) and Studio,
+following directory structure should be followed for each theme.
+
+
+.. code-block:: text
+
+   themes
+      |
+      └─ my-theme
+           ├── README.rst
+           ├─── lms
+           |     ├── static
+           |     |      └── images
+           |     |      |     └── logo.png
+           |     |      |
+           |     |      └── sass
+           |     |            └── partials
+           |     |                   └── base
+           |     |                        └── _variables.scss
+           |     |
+           |     └── templates
+           |             └── footer.html
+           |             └── header.html
+           └── cms
+                ├── static
+                |      └── images
+                |      |     └── studio-logo.png
+                |      |
+                |      └── sass
+                |            └── partials
+                |                   └── _variables.scss
+                |
+                └── templates
+                        └── login.html
+
+
+A more detailed description of how you apply themes to Studio, the LMS and the E-Commerce service and guidelines for theming templates, assets and styles can be found here_.
+
+.. _here: http://edx.readthedocs.io/projects/edx-installing-configuring-and-running/en/open-release-eucalyptus.master/configuration/changing_appearance/theming/index.html


### PR DESCRIPTION
Hi @mattdrayer , @asadiqbal08 , @douglashall 

In order for theming to setup automatically, We need to at least have have directories named `edx-platform` and `ecommerce` inside theme repo. Otherwise devstack provisioning errors out with invalid theme dirs error.

Kindly take a look at the PR and let me know if we need to also add an open source theme here ?
