### PR TITLE
docs: Update README with modern information

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -1,7 +1,28 @@
-Sample Themes for OpenEdx
-=========================
-This repository contains sample themes for LMS (Learning Management System), Studio and the E-Commerce service.
+[ARCHIVED] Sample Open edX Themes
+#################################
 
-A more detailed description of how you apply themes to Studio, the LMS and the E-Commerce service and guidelines for theming templates, assets and styles can be found here_.
+Note
+****
 
-.. _here: http://edx.readthedocs.io/projects/edx-installing-configuring-and-running/en/open-release-eucalyptus.master/configuration/changing_appearance/theming/index.html
+This repository is archived. The information contained here is no longer up to date with the most current Open edX releases.
+
+Teak and beyond
+****************
+
+`Design Tokens`_ will be the preferred system to use for theming on the Teak and future releases.
+
+Sample Tutor themes
+*******************
+
+Pre-Teak, the preferred way to theme is via Tutor. See the `Tutor documentation on theming`_.
+
+Outdated documentation (last updated for the Eucalyptus release)
+****************************************************************
+
+Note: The documentation in this repository refers to the older, deprecated E-Commerce service. Modern Open edX instances should use a `modern ecommerce solution`_.
+
+This repository contains sample themes for LMS (Learning Management System), Studio and the E-Commerce service from the Eucalyptus release.
+
+.. _Design Tokens: https://docs.openedx.org/en/latest/community/release_notes/teak/design_tokens.html
+.. _Tutor documentation on theming: https://docs.tutor.edly.io/tutorials/theming.html
+.. _modern ecommerce solution: https://docs.openedx.org/en/latest/site_ops/install_configure_run_guide/ecommerce-solutions.html


### PR DESCRIPTION
In preparation for repo archiving, update this repo's README with pointers to Design Tokens and a qualifier around the repo's contents being outdated (specifically, from the Eucalyptus release).

Resolves #16